### PR TITLE
Fix parse planes issue

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pycziutils"
-version = "0.3.0"
+version = "0.3.1"
 description = "Python utilities to read CZI files and parse metadata through python-bioformats"
 authors = ["Yohsuke T. Fukai <ysk@yfukai.net>"]
 license = "BSD license"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.3.0
+current_version = 0.3.1
 commit = True
 tag = True
 

--- a/src/pycziutils/__init__.py
+++ b/src/pycziutils/__init__.py
@@ -9,7 +9,7 @@ Parse tiled images, organize planes into pandas.DataFrame, get some hard-to-get 
 
 __author__ = """Yohsuke T. Fukai"""
 __email__ = "ysk@yfukai.net"
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 
 from ._parsers import (
     parse_binning,

--- a/src/pycziutils/__init__.py
+++ b/src/pycziutils/__init__.py
@@ -22,7 +22,7 @@ from ._parsers import (
     parse_planes,
     parse_properties,
     parse_structured_annotation_dict,
-    summarize_image_size
+    summarize_image_size,
 )
 from ._readers import get_tiled_omexml_metadata, get_tiled_reader, with_javabridge
 

--- a/src/pycziutils/_parsers.py
+++ b/src/pycziutils/_parsers.py
@@ -175,9 +175,13 @@ def parse_planes(ome_xml, acquisition_timezone=0):
         planes_df = planes_df.append(df)
     for k in [n for n in names if "index" in n] + ["image", "plane"]:
         planes_df[k] = planes_df[k].astype(int)
-    planes_df["absolute_T"] = planes_df["image_acquisition_T"] + np.vectorize(
-        timedelta
-    )(seconds=planes_df["T"])
+
+    non_nan_indices = ~planes_df["T"].isna()
+    planes_df.loc[non_nan_indices, "absolute_T"] = planes_df.loc[
+        non_nan_indices, "image_acquisition_T"
+    ] + np.vectorize(timedelta)(
+        seconds=planes_df.loc[non_nan_indices, "T"].astype(np.float64)
+    )
     planes_df = planes_df.reset_index()
     channels = parse_channels(ome_xml)
     print(channels)


### PR DESCRIPTION
`parse_planes` throw an `ValueError: cannot convert float NaN to integer` when the column `T` includes NaN. This fixes this issue by calculating `absolute_T` only for finite `T`s.
